### PR TITLE
Change Slack notification urgency message

### DIFF
--- a/.github/workflows/Slack_Urgent_Notification.yml
+++ b/.github/workflows/Slack_Urgent_Notification.yml
@@ -37,10 +37,7 @@ jobs:
         if: ${{ steps.label_check.outputs.hasUrgent == 'true' }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
-          payload: |
-            {
-              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
-              "text": "🚨 Urgent PR: <${{ steps.label_check.outputs.url }}|${{ steps.label_check.outputs.title }}> needs review within 30 minutes!"
-            }
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}   
+          slack-message: "🚨 Urgent PR: <${{ steps.label_check.outputs.url }}|${{ steps.label_check.outputs.title }}> needs review within ASAP!"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Updated Slack notification message to request review ASAP instead of within 30 minutes.